### PR TITLE
启用指定用户名和密码

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -29,7 +29,7 @@ type Connection struct {
 	options Options
 }
 
-func Connect(host string, options Options) (*Connection, error) {
+func Connect(host, username, password string, options Options) (*Connection, error) {
 	transport, err := thrift.NewTSocket(host)
 	if err != nil {
 		return nil, err
@@ -52,6 +52,8 @@ func Connect(host string, options Options) (*Connection, error) {
 	client := inf.NewTCLIServiceClientFactory(transport, protocol)
 	s := inf.NewTOpenSessionReq()
 	s.ClientProtocol = 6
+	s.Username = &username
+	s.Password = &password
 	session, err := client.OpenSession(context.Background(), s)
 	if err != nil {
 		return nil, err

--- a/connection_test.go
+++ b/connection_test.go
@@ -14,7 +14,7 @@ func TestShowTables(t *testing.T) {
 		ct        int = 0
 		tableName string
 	)
-	conn, err := Connect("114.215.255.134:10000", DefaultOptions)
+	conn, err := Connect("localhost:10000", "mapr", "mapr", DefaultOptions)
 	if err != nil {
 		t.Fatalf("Connect error %v", err)
 	}


### PR DESCRIPTION
我认为没有办法从应用程序中设置它，所以我在图书馆中做到了这一点
请告诉我，如果方式不同


ユーザ名とパスワードを指定出来るようにした

アプリケーションから設定する方法が無いと思ったのでライブラリで出来るようにしました
もしやり方が違ってたら教えてください

https://translate.google.co.jp/?hl=ja&tab=TT#ja/zh-CN/